### PR TITLE
Create Primary Keys Properly

### DIFF
--- a/src/Migrations/0000_00_00_000000_create_achievements_tables.php
+++ b/src/Migrations/0000_00_00_000000_create_achievements_tables.php
@@ -46,7 +46,7 @@ class CreateAchievementsTables extends Migration
             $this->achievementProgressTableName,
             function (Blueprint $table) {
                 $table->uuid('id')->primary();
-                $table->unsignedInteger('achievement_id');
+                $table->unsignedBigInteger('achievement_id');
                 $table->morphs('achiever');
                 $table->unsignedInteger('points')->default(0);
                 $table->timestamp('unlocked_at')->nullable()->default(null);

--- a/src/Migrations/0000_00_00_000000_create_achievements_tables.php
+++ b/src/Migrations/0000_00_00_000000_create_achievements_tables.php
@@ -33,7 +33,7 @@ class CreateAchievementsTables extends Migration
         Schema::create(
             $this->achievementDetailsTableName,
             static function (Blueprint $table) {
-                $table->increments('id');
+                $table->id();
                 $table->string('name');
                 $table->string('description');
                 $table->unsignedInteger('points')->default(1);


### PR DESCRIPTION
This pull request updates the `0000_00_00_000000_create_achievements_tables.php` migration to create the ID using the `$table->id()` method.

This prevents the `Unable to create or change a table without a primary key` error shown on some cloud database providers that enforce `sql_require_primary_key` such as DigitalOcean and follows Laravel best practice.