### PR TITLE
Add load migration config parameter

### DIFF
--- a/src/AchievementsServiceProvider.php
+++ b/src/AchievementsServiceProvider.php
@@ -42,13 +42,16 @@ class AchievementsServiceProvider extends ServiceProvider
                 ],
                 'migrations'
             );
+
+            if (config('achievements.load_migrations', true)) {
+                $this->loadMigrationsFrom(__DIR__ . '/Migrations');
+            }
         }
 
         $this->app[Achievement::class] = static function ($app) {
             return $app['gstt.achievements.achievement'];
         };
 
-        $this->loadMigrationsFrom(__DIR__ . '/Migrations');
 
         $this->mergeConfigFrom(__DIR__.'/config/achievements.php', 'achievements');
     }

--- a/src/AchievementsServiceProvider.php
+++ b/src/AchievementsServiceProvider.php
@@ -22,7 +22,6 @@ class AchievementsServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        $this->loadMigrationsFrom(__DIR__ . '/Migrations');
         if ($this->app->runningInConsole()) {
             $this->commands(
                 [
@@ -31,23 +30,27 @@ class AchievementsServiceProvider extends ServiceProvider
                     LoadAchievementsCommand::class
                 ]
             );
+            $this->publishes(
+                [
+                    __DIR__.'/config/achievements.php' => config_path('achievements.php'),
+                ],
+                'config'
+            );
+            $this->publishes(
+                [
+                    __DIR__.'/Migrations/0000_00_00_000000_create_achievements_tables.php' => database_path('migrations/000_00_00_000000_create_achievements_tables.php')
+                ],
+                'migrations'
+            );
         }
+
         $this->app[Achievement::class] = static function ($app) {
             return $app['gstt.achievements.achievement'];
         };
-        $this->publishes(
-            [
-                __DIR__ . '/config/achievements.php' => config_path('achievements.php'),
-            ],
-            'config'
-        );
-        $this->publishes(
-            [
-                __DIR__ . '/Migrations/0000_00_00_000000_create_achievements_tables.php' => database_path('migrations/000_00_00_000000_create_achievements_tables.php')
-            ],
-            'migrations'
-        );
-        $this->mergeConfigFrom(__DIR__ . '/config/achievements.php', 'achievements');
+
+        $this->loadMigrationsFrom(__DIR__ . '/Migrations');
+
+        $this->mergeConfigFrom(__DIR__.'/config/achievements.php', 'achievements');
     }
 
     /**

--- a/src/config/achievements.php
+++ b/src/config/achievements.php
@@ -26,6 +26,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Load migration
+    |--------------------------------------------------------------------------
+    |
+    | Controls if the migration file should be automatically loaded.
+    |
+    | When set to TRUE, the migrations are autoloaded into the migration's folder.
+    | If you would like to update your file or store the migration file from a different
+    | path you should set this to FALSE.
+    |
+    */
+    'load_migrations' => true,
+
+
+    /*
+    |--------------------------------------------------------------------------
     | Locked achievement sync
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Hello,

I've just found out your package and it seems really cool ! I'm glad it was just updated to Laravel 9.

I installed the package and I have two issues: 

1) The migration fails, and I'm not quite sure why :
```
SQLSTATE[HY000]: General error: 1215 Cannot add foreign key constraint (SQL: alter table `achievement_progress` add constraint `achievement_progress_achievement_id_foreign` foreign key (`achievement_id`) references `achievement_det
ails` (`id`))
```
I'm guessing it's related to my setup, because I have multiple database connections... ¯\_(ツ)_/¯

2) In my project I have multi-tenants, the tenants migrations are stored in a sub-folder. The package loads the migration in the `/Migrations` folder but I need it to be in the `/Migrations/tenant` folder.


So this PR adds a config parameter to enable or disable the migration loader. This is similar to what [Laravel Cashier](https://github.com/laravel/cashier-stripe/blob/13.x/src/CashierServiceProvider.php#L133) does but with the config instead of a static property. This allows me to write my own migration and adapt to my project.

Also, I changed so that all the publishables load only when running in the console.