### PR TITLE
"(Fixed migrarions issue for "achievement_progress_achievement_id_foreign"")

### DIFF
--- a/src/Migrations/0000_00_00_000000_create_achievements_tables.php
+++ b/src/Migrations/0000_00_00_000000_create_achievements_tables.php
@@ -46,7 +46,7 @@ class CreateAchievementsTables extends Migration
             $this->achievementProgressTableName,
             function (Blueprint $table) {
                 $table->uuid('id')->primary();
-                $table->unsignedInteger('achievement_id');
+                $table->unsignedBigInteger('achievement_id');
                 $table->morphs('achiever');
                 $table->unsignedInteger('points')->default(0);
                 $table->timestamp('unlocked_at')->nullable()->default(null);


### PR DESCRIPTION
## Issue in migarion that produces the following error
- `Illuminate\Database\QueryException : SQLSTATE[HY000]: General error: 3780 Referencing column 'achievement_id' and referenced column 'id' in foreign key constraint 'achievement_progress_achievement_id_foreign' are incompatible. (SQL: alter table `achievement_progress` add constraint `achievement_progress_achievement_id_foreign` foreign key (`achievement_id`) references `achievement_details` (`id`))`

## Fix is pretty simple just use the same type for both keys as mention in this [Issue](https://github.com/assada/laravel-achievements/issues/18)