### PR TITLE
Fixed path of loadMigrationsFrom

### DIFF
--- a/src/AchievementsServiceProvider.php
+++ b/src/AchievementsServiceProvider.php
@@ -22,7 +22,7 @@ class AchievementsServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        $this->loadMigrationsFrom(__DIR__ . '/Migrations');
+        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
         if ($this->app->runningInConsole()) {
             $this->commands(
                 [


### PR DESCRIPTION
On a fresh app it gave the error "Cannot declare class CreateAchievementsTables, because the name is already in use" when trying to migrate, i notice missing 'database' folder in loadMigrationsFrom method.

I used https://laravel.com/docs/9.x/packages#migrations as reference and it now it completes the migration without issues.