### PR TITLE
chore: add Gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto
+
+# Path-based git attributes
+# https://git-scm.com/docs/gitattributes
+
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/docs               export-ignore
+/phpunit.xml        export-ignore
+/tests              export-ignore


### PR DESCRIPTION
This adds a `.gitattributes` file to ensure that tests and docs aren't distributed when installing.